### PR TITLE
return to previous directory when you exit kr

### DIFF
--- a/aliases.sh
+++ b/aliases.sh
@@ -21,11 +21,11 @@ os161-config() {
 }
 
 os161-run() {
-    cd ~/cs161/root && sys161 kernel
+    bash -c "cd ~/cs161/root && sys161 kernel"
 }
 
 os161-debug() {
-    cd ~/cs161/root && sys161 -w kernel
+    bash -c "cd ~/cs161/root && sys161 -w kernel"
 }
 
 os161-user-build() {


### PR DESCRIPTION
I tried using pushd and popd, but this fails when the user exits
with a ctrl-c.  I think this happens becuase the ctrl-c ends the
bash function as well as the kernel, so we never get to the popd.
It did work when the user exits cleanly (with an "exit" command),
but I prefer to exit with a ctrl-c.

By using a subprocess, when we ctrl-c the subprocess we return to
the calling shell's original directory, which is what we want.
