### PR TITLE
add the ability to pass arguments to kr/kd

### DIFF
--- a/aliases.sh
+++ b/aliases.sh
@@ -21,11 +21,11 @@ os161-config() {
 }
 
 os161-run() {
-    bash -c "cd ~/cs161/root && sys161 kernel"
+    bash -c "cd ~/cs161/root && sys161 kernel \"$@\""
 }
 
 os161-debug() {
-    bash -c "cd ~/cs161/root && sys161 -w kernel"
+    bash -c "cd ~/cs161/root && sys161 -w kernel \"$@\""
 }
 
 os161-user-build() {


### PR DESCRIPTION
For example, `kr "p /testbin/add; exit"` will run
sys161 "p /testbin/add; exit"
which tells the kernel to run `p /testbin/add` without prompting
you to enter a command to the OS via stdin.
