### PR TITLE
Blazing fast builds

### DIFF
--- a/aliases.sh
+++ b/aliases.sh
@@ -6,7 +6,7 @@ os161-build() {
         return 1
     fi
     pushd "$HOME/cs161/os161/kern/compile/$1"
-    bmake depend && bmake && bmake install
+    bmake -s -j4 depend && bmake -j4 && bmake install -s
     popd
 }
 
@@ -29,11 +29,16 @@ os161-debug() {
 }
 
 os161-user-build() {
+    if [ "$1" ]; then
+        pushd "$HOME/cs161/os161/userland/$1"
+        bmake depend -s && bmake && bmake install
+        return 0
+    fi
     pushd "$HOME/cs161/os161/"
-    bmake
+    bmake -s
     popd
     pushd "$HOME/cs161/os161/userland"
-    bmake depend && bmake && bmake install
+    bmake -s -j4 depend && bmake -s -j4 && bmake install -s -j4
     popd
 }
 

--- a/aliases.sh
+++ b/aliases.sh
@@ -6,7 +6,7 @@ os161-build() {
         return 1
     fi
     pushd "$HOME/cs161/os161/kern/compile/$1"
-    bmake -s -j4 depend && bmake -j4 && bmake install -s
+    bmake -j4 && bmake install -s
     popd
 }
 
@@ -18,6 +18,10 @@ os161-config() {
     pushd "$HOME/cs161/os161/kern/conf"
     ./config "$1"
     popd
+    pushd "$HOME/cs161/os161/kern/compile/$1"
+    bmake -s -j4 depend
+    popd
+    os161-build "$1"
 }
 
 os161-run() {


### PR DESCRIPTION
builds are now silent and parallelized, improving speed

`kb` doesn't do `bmake depend`, which makes it super fast
`kc` does the `bmake depend` instead, after `./config`, then does the `kb` for you

Most of the time, you don't need a `bmake depend`, and it is "pig dog slow".  When you do need it, the extra  `./config` doesn't hurt.

`ub` now optionally takes an argument of a specific subdirectory to build.  If you're working on one test, which is the common case, this is blazing fast.

All of the above are subsecond performant, where previously the worst of them, (`ub`,) took over 7 seconds on my machine 
